### PR TITLE
Add .env example and update setup docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@
 *.pdf
 Uploads/
 
+# Local environment files
+.env
+zettelkasten_ai_app/.env
+
 # OS
 .DS_Store
 anzu_altar_2.txt

--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@ This project is an interactive knowledge base for exploring AI consciousness, he
 
 1. Install dependencies
    ```bash
+   cd zettelkasten_ai_app
    npm install
    ```
-2. (Optional) configure Gemini
+2. (Optional) configure Gemini and Google APIs
    ```bash
    cp .env.example .env
-   # add your Gemini API key
+   # add your API keys
    GEMINI_API_KEY=your_api_key_here
+   VITE_GOOGLE_API_KEY=your_google_key_here
    ```
 3. Start the development server
    ```bash

--- a/zettelkasten_ai_app/.env.example
+++ b/zettelkasten_ai_app/.env.example
@@ -1,0 +1,2 @@
+GEMINI_API_KEY=your_api_key_here
+VITE_GOOGLE_API_KEY=your_google_key_here

--- a/zettelkasten_ai_app/README.md
+++ b/zettelkasten_ai_app/README.md
@@ -76,15 +76,16 @@ src/
 
 1. **Clone and Install**:
    ```bash
-   cd /home/ubuntu/zettelkasten_ai_app
+   cd zettelkasten_ai_app
    npm install
    ```
 
 2. **Configure AI (Optional)**:
    ```bash
    cp .env.example .env
-   # Add your Gemini API key to .env
+   # Add your API keys to .env
    GEMINI_API_KEY=your_api_key_here
+   VITE_GOOGLE_API_KEY=your_google_key_here
    ```
 
 3. **Run Development Server**:

--- a/zettelkasten_ai_app/src/components/Sidebar.tsx
+++ b/zettelkasten_ai_app/src/components/Sidebar.tsx
@@ -34,12 +34,12 @@ const Sidebar: React.FC<SidebarProps> = ({ rainbowMode = false }) => {
   });
   
   const location = useLocation();
-  const { trunks, entries } = useKnowledge();
+  const { trunks, allEntries } = useKnowledge();
 
   // Calculate system stats
   useEffect(() => {
-    const totalZettels = entries.length;
-    const totalConnections = entries.reduce((acc, entry) => acc + (entry.connections?.length || 0), 0);
+    const totalZettels = allEntries.length;
+    const totalConnections = allEntries.reduce((acc, entry) => acc + (entry.connections?.length || 0), 0);
     const activeProcesses = Math.floor(Math.random() * 50) + 20; // Simulated
     const memoryUsage = Math.floor(Math.random() * 30) + 60; // Simulated
 
@@ -49,7 +49,7 @@ const Sidebar: React.FC<SidebarProps> = ({ rainbowMode = false }) => {
       activeProcesses,
       memoryUsage
     });
-  }, [entries]);
+  }, [allEntries]);
 
   const toggleSection = (section: string) => {
     const newExpanded = new Set(expandedSections);


### PR DESCRIPTION
## Summary
- add example environment file to `zettelkasten_ai_app`
- mention copying the example env file in both READMEs
- ignore `.env` files and adjust setup instructions
- fix error in sidebar stats by using `allEntries`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685dcd444130832b9531ec4d495dc2d6