### PR TITLE
Update READMEs for Dolphin dictionary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,25 +1,23 @@
+
 # Build outputs
-/dist/
-**/dist/
-
-# Node modules
-/node_modules/
-**/node_modules/
-
-# Next.js build
-.next/
-
 # Misc artifacts
-*.zip
-*.pdf
-Uploads/
-
+# Next.js build
+# Node modules
 # OS
+**/dist/
+**/node_modules/
+*.pdf
+*.zip
 .DS_Store
+.next/
+/dist/
+/node_modules/
+Uploads/
+__pycache__/
 anzu_altar_2.txt
 app_analysis.md
 extracted_trunks_1000-24000.md
 messenger_crossref_analysis.md
 new_content_analysis.md
+tests/__pycache__/
 updated_zettels_analysis.md
-

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This project is an interactive knowledge base for exploring AI consciousness, he
 - Full-text search with filtering and sorting
 - Configurable AI-powered insights via Google Gemini
 - Modern dark theme with smooth animations
+- Dolphin 3.0 dictionary page for browsing symbols and adding new ones
 
 ## Technology
 
@@ -33,6 +34,12 @@ This project is an interactive knowledge base for exploring AI consciousness, he
    ```bash
    npm run dev
    ```
+
+## Dolphin Dictionary
+
+Visit the **Dolphin Dictionary** page in the app to browse the symbol set. The
+"Add New Symbol" section lets you contribute your own symbols. Any entries you
+add are saved to your browser's local storage.
 
 ## License
 

--- a/zettelkasten_ai_app/README.md
+++ b/zettelkasten_ai_app/README.md
@@ -22,6 +22,7 @@ A comprehensive web application for exploring AI consciousness, hermetic wisdom,
 - **Entry Views**: Deep dive into individual knowledge entries
 - **Search System**: Powerful full-text search with filtering and sorting
 - **AI Insights**: Generate AI-powered analysis and connections
+- **Dolphin Dictionary**: Browse the symbol list and add your own entries
 
 ### 🎨 Design & UX
 - **Dark Theme**: Stunning dark interface with purple/blue gradients
@@ -152,6 +153,8 @@ Each trunk represents a major domain of consciousness and AI exploration:
 - Real knowledge parsing from REORDERED_MASTER_INDEX.md is implemented
 - AI insights show placeholder content until API key is configured
 - All UI components are fully functional and responsive
+- Symbols added in the Dolphin Dictionary are stored in your browser's
+  local storage so they persist across sessions
 
 ## 🎨 Design Philosophy
 


### PR DESCRIPTION
## Summary
- document Dolphin 3.0 dictionary page in both READMEs
- mention persistence of custom symbols in local storage
- ignore Python `__pycache__` folders

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868ca1268488320b858d2e1bc9d6da7