### PR TITLE
Check duplicates when adding dolphin symbol

### DIFF
--- a/zettelkasten_ai_app/src/pages/DolphinDictionary.tsx
+++ b/zettelkasten_ai_app/src/pages/DolphinDictionary.tsx
@@ -25,8 +25,15 @@ export default function DolphinDictionary() {
 
   const addEntry = () => {
     if (!newSymbol.trim() || !newName.trim() || !newMeaning.trim()) return;
+
+    const symbol = newSymbol.trim();
+    if (entries.some(e => e.symbol === symbol)) {
+      alert('This symbol already exists in the dictionary.');
+      return;
+    }
+
     const newEntry: DolphinSymbol = {
-      symbol: newSymbol.trim(),
+      symbol,
       name: newName.trim(),
       meaning: newMeaning.trim()
     };


### PR DESCRIPTION
## Summary
- prevent duplicate dolphin symbols from being added

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868ca0c7b7c8320808cb44b2ddcd665